### PR TITLE
[FIX] hr_timesheet_attendance: Allow update module

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -17,6 +17,7 @@ class TimesheetAttendance(models.Model):
 
     @api.model_cr
     def init(self):
+        self._cr.execute("DROP VIEW IF EXISTS hr_timesheet_attendance_report")
         self._cr.execute("""CREATE OR REPLACE VIEW %s AS (
             SELECT
                 max(id) AS id,


### PR DESCRIPTION
In PostgreSQL, we can't CREATE OR REPLACE VIEW if there is the type of the column change.
To fix it, just drop the view before creating it

closes odoo/odoo#34851

Signed-off-by: Yannick Tivisse (yti) <yti@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
